### PR TITLE
entry is null if text is dragged onto the dropzone

### DIFF
--- a/src/Html5FileSelector.js
+++ b/src/Html5FileSelector.js
@@ -87,10 +87,12 @@ export function getDataTransferFiles(dataTransfer) {
     if (typeof listItem.webkitGetAsEntry === 'function') {
       const entry = listItem.webkitGetAsEntry();
 
-      if (entry && entry.isDirectory) {
-        folderPromises.push(traverseDirectory(entry));
-      } else {
-        filePromises.push(getFile(entry));
+      if (entry) {
+        if (entry.isDirectory) {
+          folderPromises.push(traverseDirectory(entry));
+        } else {
+          filePromises.push(getFile(entry));
+        }
       }
     } else {
       dataTransferFiles.push(listItem);


### PR DESCRIPTION
Found while using with react-dropzone. If text or any element other than a file is dropped, getFile throws