### PR TITLE
return proper fullPath when upload via file selector

### DIFF
--- a/src/Html5FileSelector.js
+++ b/src/Html5FileSelector.js
@@ -70,7 +70,7 @@ function packageFile(file, entry) {
   }
   return {
     fileObject: file, // provide access to the raw File object (required for uploading)
-    fullPath: entry ? copyString(entry.fullPath) : file.name,
+    fullPath: entry ? copyString(entry.fullPath) : file.webkitRelativePath,
     lastModified: file.lastModified,
     lastModifiedDate: file.lastModifiedDate,
     name: file.name,


### PR DESCRIPTION
- when we select file via Drag and Drop event , it's fullPath is entry.fullPath.
- when we select file via file selector , it's fullPath is actually file.webkitRelativePath.

This change let us get the file path more convinient :) .